### PR TITLE
Change shell prompts to read "python3" vs "python"

### DIFF
--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -84,7 +84,6 @@ class TemplateCommand(BaseCommand):
         )
 
     def handle(self, app_or_project, name, target=None, **options):
-        self.written_files = []
         self.app_or_project = app_or_project
         self.a_or_an = "an" if app_or_project == "app" else "a"
         self.paths_to_remove = []
@@ -209,7 +208,6 @@ class TemplateCommand(BaseCommand):
                 else:
                     shutil.copyfile(old_path, new_path)
 
-                self.written_files.append(new_path)
                 if self.verbosity >= 2:
                     self.stdout.write("Creating %s" % new_path)
                 try:
@@ -232,7 +230,7 @@ class TemplateCommand(BaseCommand):
                 else:
                     shutil.rmtree(path_to_remove)
 
-        run_formatters(self.written_files, **formatter_paths)
+        run_formatters([top_dir], **formatter_paths)
 
     def handle_template(self, template, subdir):
         """

--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -172,7 +172,7 @@ Go ahead and install the previously cloned copy of Django:
 
 .. console::
 
-    $ python -m pip install -e /path/to/your/local/clone/django/
+    $ python3 -m pip install -e /path/to/your/local/clone/django/
 
 The installed version of Django is now pointing at your local copy by installing
 in editable mode. You will immediately see any changes you make to it, which is
@@ -204,7 +204,7 @@ Before running the test suite, enter the Django ``tests/`` directory using the
 
 .. console::
 
-    $ python -m pip install -r requirements/py3.txt
+    $ python3 -m pip install -r requirements/py3.txt
 
 If you encounter an error during the installation, your system might be missing
 a dependency for one or more of the Python packages. Consult the failing

--- a/docs/intro/install.txt
+++ b/docs/intro/install.txt
@@ -19,7 +19,7 @@ database called SQLite_ so you won't need to set up a database just yet.
 Get the latest version of Python at https://www.python.org/downloads/ or with
 your operating system's package manager.
 
-You can verify that Python is installed by typing ``python`` from your shell;
+You can verify that Python is installed by typing ``python3`` from your shell;
 you should see something like::
 
     Python 3.x.y
@@ -65,7 +65,7 @@ You've got three options to install Django:
 Verifying
 =========
 
-To verify that Django can be seen by Python, type ``python`` from your shell.
+To verify that Django can be seen by Python, type ``python3`` from your shell.
 Then at the Python prompt, try to import Django:
 
 .. parsed-literal::

--- a/docs/intro/overview.txt
+++ b/docs/intro/overview.txt
@@ -53,8 +53,8 @@ automatically:
 
 .. console::
 
-    $ python manage.py makemigrations
-    $ python manage.py migrate
+    $ python3 manage.py makemigrations
+    $ python3 manage.py migrate
 
 The :djadmin:`makemigrations` command looks at all your available models and
 creates migrations for whichever tables don't already exist. :djadmin:`migrate`

--- a/docs/intro/reusable-apps.txt
+++ b/docs/intro/reusable-apps.txt
@@ -169,7 +169,7 @@ this. For a small app like polls, this process isn't too difficult.
 
            path('polls/', include('polls.urls')),
 
-       3. Run ``python manage.py migrate`` to create the polls models.
+       3. Run ``python3 manage.py migrate`` to create the polls models.
 
        4. Start the development server and visit http://127.0.0.1:8000/admin/
           to create a poll (you'll need the Admin app enabled).
@@ -264,7 +264,7 @@ this. For a small app like polls, this process isn't too difficult.
    you add some files to it. Many Django apps also provide their documentation
    online through sites like `readthedocs.org <https://readthedocs.org>`_.
 
-#. Try building your package with ``python setup.py sdist`` (run from inside
+#. Try building your package with ``python3 setup.py sdist`` (run from inside
    ``django-polls``). This creates a directory called ``dist`` and builds your
    new package, ``django-polls-0.1.tar.gz``.
 
@@ -293,14 +293,14 @@ working. We'll now fix this by installing our new ``django-polls`` package.
 #. To install the package, use pip (you already :ref:`installed it
    <installing-reusable-apps-prerequisites>`, right?)::
 
-    python -m pip install --user django-polls/dist/django-polls-0.1.tar.gz
+    python3 -m pip install --user django-polls/dist/django-polls-0.1.tar.gz
 
 #. With luck, your Django project should now work correctly again. Run the
    server again to confirm this.
 
 #. To uninstall the package, use pip::
 
-    python -m pip uninstall django-polls
+    python3 -m pip uninstall django-polls
 
 Publishing your app
 ===================

--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -18,7 +18,7 @@ in a shell prompt (indicated by the $ prefix):
 
 .. console::
 
-    $ python -m django --version
+    $ python3 -m django --version
 
 If Django is installed, you should see the version of your installation. If it
 isn't, you'll get an error telling "No module named django".
@@ -126,7 +126,7 @@ you haven't already, and run the following commands:
 
 .. console::
 
-   $ python manage.py runserver
+   $ python3 manage.py runserver
 
 You'll see the following output on the command line:
 
@@ -172,7 +172,7 @@ It worked!
 
     .. console::
 
-        $ python manage.py runserver 8080
+        $ python3 manage.py runserver 8080
 
     If you want to change the server's IP, pass it along with the port. For
     example, to listen on all available public IPs (which is useful if you are
@@ -181,7 +181,7 @@ It worked!
 
     .. console::
 
-        $ python manage.py runserver 0.0.0.0:8000
+        $ python3 manage.py runserver 0.0.0.0:8000
 
     Full docs for the development server can be found in the
     :djadmin:`runserver` reference.
@@ -222,7 +222,7 @@ and type this command:
 
 .. console::
 
-    $ python manage.py startapp polls
+    $ python3 manage.py startapp polls
 
 That'll create a directory :file:`polls`, which is laid out like this::
 
@@ -319,7 +319,7 @@ the following command:
 
 .. console::
 
-   $ python manage.py runserver
+   $ python3 manage.py runserver
 
 Go to http://localhost:8000/polls/ in your browser, and you should see the
 text "*Hello, world. You're at the polls index.*", which you defined in the

--- a/docs/intro/tutorial02.txt
+++ b/docs/intro/tutorial02.txt
@@ -407,7 +407,7 @@ Once you're in the shell, explore the :doc:`database API </topics/db/queries>`::
     >>> q.question_text
     "What's new?"
     >>> q.pub_date
-    datetime.datetime(2012, 2, 26, 13, 0, 0, 775217, tzinfo=<UTC>)
+    datetime.datetime(2012, 2, 26, 13, 0, 0, 775217, tzinfo=datetime.timezone.utc)
 
     # Change values by changing the attributes, then calling save().
     >>> q.question_text = "What's up?"

--- a/docs/intro/tutorial02.txt
+++ b/docs/intro/tutorial02.txt
@@ -92,7 +92,7 @@ that, run the following command:
 
 .. console::
 
-    $ python manage.py migrate
+    $ python3 manage.py migrate
 
 The :djadmin:`migrate` command looks at the :setting:`INSTALLED_APPS` setting
 and creates any necessary database tables according to the database settings
@@ -233,7 +233,7 @@ Now Django knows to include the ``polls`` app. Let's run another command:
 
 .. console::
 
-    $ python manage.py makemigrations polls
+    $ python3 manage.py makemigrations polls
 
 You should see something similar to the following:
 
@@ -262,7 +262,7 @@ moment - but first, let's see what SQL that migration would run. The
 
 .. console::
 
-    $ python manage.py sqlmigrate polls 0001
+    $ python3 manage.py sqlmigrate polls 0001
 
 You should see something similar to the following (we've reformatted it for
 readability):
@@ -327,14 +327,14 @@ Note the following:
   changes.
 
 If you're interested, you can also run
-:djadmin:`python manage.py check <check>`; this checks for any problems in
+:djadmin:`python3 manage.py check <check>`; this checks for any problems in
 your project without making migrations or touching the database.
 
 Now, run :djadmin:`migrate` again to create those model tables in your database:
 
 .. console::
 
-    $ python manage.py migrate
+    $ python3 manage.py migrate
     Operations to perform:
       Apply all migrations: admin, auth, contenttypes, polls, sessions
     Running migrations:
@@ -354,9 +354,9 @@ losing data. We'll cover them in more depth in a later part of the tutorial,
 but for now, remember the three-step guide to making model changes:
 
 * Change your models (in ``models.py``).
-* Run :djadmin:`python manage.py makemigrations <makemigrations>` to create
+* Run :djadmin:`python3 manage.py makemigrations <makemigrations>` to create
   migrations for those changes
-* Run :djadmin:`python manage.py migrate <migrate>` to apply those changes to
+* Run :djadmin:`python3 manage.py migrate <migrate>` to apply those changes to
   the database.
 
 The reason that there are separate commands to make and apply migrations is
@@ -375,9 +375,9 @@ API Django gives you. To invoke the Python shell, use this command:
 
 .. console::
 
-    $ python manage.py shell
+    $ python3 manage.py shell
 
-We're using this instead of simply typing "python", because :file:`manage.py`
+We're using this instead of simply typing "python3", because :file:`manage.py`
 sets the :envvar:`DJANGO_SETTINGS_MODULE` environment variable, which gives
 Django the Python import path to your :file:`mysite/settings.py` file.
 
@@ -468,7 +468,7 @@ you aren't familiar with time zone handling in Python, you can learn more in
 the :doc:`time zone support docs </topics/i18n/timezones>`.
 
 Save these changes and start a new Python interactive shell by running
-``python manage.py shell`` again::
+``python3 manage.py shell`` again::
 
     >>> from polls.models import Choice, Question
 
@@ -578,7 +578,7 @@ following command:
 
 .. console::
 
-    $ python manage.py createsuperuser
+    $ python3 manage.py createsuperuser
 
 Enter your desired username and press enter.
 
@@ -611,7 +611,7 @@ If the server is not running start it like so:
 
 .. console::
 
-    $ python manage.py runserver
+    $ python3 manage.py runserver
 
 Now, open a web browser and go to "/admin/" on your local domain -- e.g.,
 http://127.0.0.1:8000/admin/. You should see the admin's login screen:

--- a/docs/intro/tutorial05.txt
+++ b/docs/intro/tutorial05.txt
@@ -144,7 +144,7 @@ whose date lies in the future:
 
 .. console::
 
-    $ python manage.py shell
+    $ python3 manage.py shell
 
 .. code-block:: pycon
 
@@ -204,7 +204,7 @@ In the terminal, we can run our test:
 
 .. console::
 
-    $ python manage.py test polls
+    $ python3 manage.py test polls
 
 and you'll see something like::
 
@@ -358,7 +358,7 @@ environment in the :djadmin:`shell`:
 
 .. console::
 
-    $ python manage.py shell
+    $ python3 manage.py shell
 
 .. code-block:: pycon
 

--- a/docs/intro/tutorial06.txt
+++ b/docs/intro/tutorial06.txt
@@ -84,7 +84,7 @@ Start the server (or restart it if it's already running):
 
 .. console::
 
-    $ python manage.py runserver
+    $ python3 manage.py runserver
 
 Reload ``http://localhost:8000/polls/`` and you should see that the question
 links are green (Django style!) which means that your stylesheet was properly

--- a/docs/intro/tutorial07.txt
+++ b/docs/intro/tutorial07.txt
@@ -352,7 +352,7 @@ template directory in the source code of Django itself
 
     .. console::
 
-        $ python -c "import django; print(django.__path__)"
+        $ python3 -c "import django; print(django.__path__)"
 
 Then, edit the file and replace
 ``{{ site_header|default:_('Django administration') }}`` (including the curly

--- a/docs/intro/whatsnext.txt
+++ b/docs/intro/whatsnext.txt
@@ -163,7 +163,7 @@ You can get a local copy of the HTML documentation following a few steps:
 
   .. console::
 
-        $ python -m pip install Sphinx
+        $ python3 -m pip install Sphinx
 
 * Then, use the included ``Makefile`` to turn the documentation into HTML:
 

--- a/docs/ref/models/database-functions.txt
+++ b/docs/ref/models/database-functions.txt
@@ -721,8 +721,8 @@ Usage example::
     {'date': datetime.date(2014, 6, 15),
      'day': datetime.datetime(2014, 6, 16, 0, 0, tzinfo=zoneinfo.ZoneInfo('Australia/Melbourne')),
      'hour': datetime.datetime(2014, 6, 16, 0, 0, tzinfo=zoneinfo.ZoneInfo('Australia/Melbourne')),
-     'minute': 'minute': datetime.datetime(2014, 6, 15, 14, 30, tzinfo=zoneinfo.ZoneInfo('UTC')),
-     'second': datetime.datetime(2014, 6, 15, 14, 30, 50, tzinfo=zoneinfo.ZoneInfo('UTC'))
+     'minute': 'minute': datetime.datetime(2014, 6, 15, 14, 30, tzinfo=timezone.utc),
+     'second': datetime.datetime(2014, 6, 15, 14, 30, 50, tzinfo=timezone.utc)
     }
 
 ``TimeField`` truncation

--- a/docs/ref/signals.txt
+++ b/docs/ref/signals.txt
@@ -80,7 +80,7 @@ Argument    Value
             arguments passed to ``__init__()``)
 
 ``kwargs``  ``{'question_text': "What's new?",``
-            ``'pub_date': datetime.datetime(2012, 2, 26, 13, 0, 0, 775217, tzinfo=<UTC>)}``
+            ``'pub_date': datetime.datetime(2012, 2, 26, 13, 0, 0, 775217, tzinfo=datetime.timezone.utc)}``
 ==========  ===============================================================
 
 ``post_init``

--- a/docs/releases/4.1.3.txt
+++ b/docs/releases/4.1.3.txt
@@ -9,4 +9,6 @@ Django 4.1.3 fixes several bugs in 4.1.2.
 Bugfixes
 ========
 
-* ...
+* Fixed a bug in Django 4.1 that caused non-Python files created by
+  ``startproject`` and ``startapp`` management commands from custom templates
+  to be incorrectly formatted using the ``black`` command (:ticket:`34085`).

--- a/tests/admin_scripts/custom_templates/project_template/additional_dir/requirements.in
+++ b/tests/admin_scripts/custom_templates/project_template/additional_dir/requirements.in
@@ -1,0 +1,5 @@
+# Should not be processed by `black`.
+Django<4.2
+environs[django]
+psycopg2-binary
+django-extensions

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -2483,6 +2483,23 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         self.assertTrue(os.path.isdir(testproject_dir))
         self.assertTrue(os.path.exists(os.path.join(testproject_dir, "additional_dir")))
 
+    def test_custom_project_template_non_python_files_not_formatted(self):
+        template_path = os.path.join(custom_templates_dir, "project_template")
+        args = ["startproject", "--template", template_path, "customtestproject"]
+        testproject_dir = os.path.join(self.test_dir, "customtestproject")
+
+        _, err = self.run_django_admin(args)
+        self.assertNoOutput(err)
+        with open(
+            os.path.join(template_path, "additional_dir", "requirements.in")
+        ) as f:
+            expected = f.read()
+        with open(
+            os.path.join(testproject_dir, "additional_dir", "requirements.in")
+        ) as f:
+            result = f.read()
+        self.assertEqual(expected, result)
+
     def test_template_dir_with_trailing_slash(self):
         "Ticket 17475: Template dir passed has a trailing path separator"
         template_path = os.path.join(custom_templates_dir, "project_template" + os.sep)


### PR DESCRIPTION
Since this is a tutorial written largely for novices, it is more user friendly to have the shell prompts be "python3". The tutorial states that "This tutorial is written for Django |version|, which supports Python 3.8 and later." So it is safe to assume the user is using python3 for shell prompts. Any experienced python developer who is using an alias such as python-is-python3 will now to substitute python for python3, but a novice will not necessarily know to do the inverse.